### PR TITLE
Adding underscore to the "exotic characters in the structure/template names" ;)

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -138,7 +138,7 @@ var utilities = {
                 } else {
                     for (var i = 0; i < result.root[type].length; i++) {
                         val = result.root[type][i]._;
-                        val = val.replace(/[^a-zA-Z0-9 \.-]/g, "");
+                        val = val.replace(/[^a-zA-Z0-9 \.-_]/g, "");
                         prop = result.root[type][i].$['language-id'];
                         out[prop] = val;
                     }


### PR DESCRIPTION
You said in documentation: 

There may be no exotic characters in the structure/template names (nothing which is not valid filename on an old Windows machine, so no slash, no comma, etc).

You make a replace of exotic characters using this regex (/[^a-zA-Z0-9 .-]/g, "") to nothing... but underscore character should be consider a valid "old windows" name... this cause we can update template (only download) because it replace RS_XXX_TEMPLATE to RSXXXTEMPLATE.

Thanks for this great tool.
